### PR TITLE
[BUGFIX] Ensure temp directory exists before calling tempnam()

### DIFF
--- a/src/Graphs/Renderer/PlantumlRenderer.php
+++ b/src/Graphs/Renderer/PlantumlRenderer.php
@@ -21,6 +21,8 @@ use Symfony\Component\Process\Process;
 use function array_merge;
 use function file_get_contents;
 use function file_put_contents;
+use function is_dir;
+use function mkdir;
 use function sys_get_temp_dir;
 use function tempnam;
 
@@ -45,7 +47,12 @@ $diagram
 @enduml
 PUML;
 
-        $pumlFileLocation = tempnam(sys_get_temp_dir() . '/phpdocumentor', 'pu_');
+        $tempDir = sys_get_temp_dir() . '/phpdocumentor';
+        if (!is_dir($tempDir)) {
+            mkdir($tempDir, 0o777, true);
+        }
+
+        $pumlFileLocation = tempnam($tempDir, 'pu_');
         file_put_contents($pumlFileLocation, $output);
         try {
             $process = new Process([$this->plantUmlBinaryPath, '-tsvg', $pumlFileLocation], __DIR__, null, null, 600.0);

--- a/src/Graphs/Renderer/PlantumlRenderer.php
+++ b/src/Graphs/Renderer/PlantumlRenderer.php
@@ -28,6 +28,8 @@ use function tempnam;
 
 final class PlantumlRenderer implements DiagramRenderer
 {
+    public const TEMP_SUBDIRECTORY = '/phpdocumentor';
+
     public function __construct(private readonly LoggerInterface $logger, private readonly string $plantUmlBinaryPath)
     {
     }
@@ -47,7 +49,7 @@ $diagram
 @enduml
 PUML;
 
-        $tempDir = sys_get_temp_dir() . '/phpdocumentor';
+        $tempDir = sys_get_temp_dir() . self::TEMP_SUBDIRECTORY;
         if (!is_dir($tempDir)) {
             mkdir($tempDir, 0o777, true);
         }

--- a/tests/unit/Renderer/PlantumlRendererTest.php
+++ b/tests/unit/Renderer/PlantumlRendererTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @link https://phpdoc.org
+ */
+
+namespace phpDocumentor\Guides\Graphs\Renderer;
+
+use phpDocumentor\Guides\RenderContext;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+use function is_dir;
+use function rmdir;
+use function sys_get_temp_dir;
+
+final class PlantumlRendererTest extends TestCase
+{
+    /**
+     * @runInSeparateProcess
+     */
+    public function testRenderCreatesTempDirectoryWhenMissing(): void
+    {
+        $tempDir = sys_get_temp_dir() . '/phpdocumentor';
+
+        // Remove the directory if it exists to test creation
+        if (is_dir($tempDir)) {
+            @rmdir($tempDir);
+        }
+
+        // Skip if we can't remove it (contains files from other processes)
+        if (is_dir($tempDir)) {
+            self::markTestSkipped('Cannot remove temp directory - it contains files from other processes');
+        }
+
+        // Use a non-existent binary path - the render will fail but directory should be created first
+        $renderer = new PlantumlRenderer(new NullLogger(), '/non/existent/plantuml');
+
+        $renderContext = $this->createMock(RenderContext::class);
+        $renderContext->method('getLoggerInformation')->willReturn([]);
+
+        // The render will fail due to missing binary, but the temp directory should be created
+        $renderer->render($renderContext, 'A -> B');
+
+        self::assertDirectoryExists($tempDir);
+
+        // Clean up
+        @rmdir($tempDir);
+    }
+}

--- a/tests/unit/Renderer/PlantumlRendererTest.php
+++ b/tests/unit/Renderer/PlantumlRendererTest.php
@@ -28,7 +28,7 @@ final class PlantumlRendererTest extends TestCase
      */
     public function testRenderCreatesTempDirectoryWhenMissing(): void
     {
-        $tempDir = sys_get_temp_dir() . '/phpdocumentor';
+        $tempDir = sys_get_temp_dir() . PlantumlRenderer::TEMP_SUBDIRECTORY;
 
         // Remove the directory if it exists to test creation
         if (is_dir($tempDir)) {


### PR DESCRIPTION
## Summary

Fixes #1

The `tempnam()` call in `PlantumlRenderer::render()` uses a subdirectory of `sys_get_temp_dir()` that may not exist, which triggers a PHP `E_NOTICE`:

```
Notice: tempnam(): file created in the system's temporary directory
```

This notice can appear in rendered documentation output when error reporting includes `E_NOTICE`.

## Changes

- Create the `/phpdocumentor` subdirectory if it doesn't exist before calling `tempnam()`

## Test plan

- [ ] Configure guides to use local PlantUML binary (`renderer="plantuml"`)
- [ ] Ensure `/tmp/phpdocumentor` does not exist
- [ ] Render documentation with a `.. uml::` directive
- [ ] Verify no `E_NOTICE` is emitted